### PR TITLE
Validate Index File before publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,10 @@ jobs:
     - name: Generate Index
       id: generate_index 
       run: node src/index.js
+    - name: Fetch Current Index
+      run: curl -o old-index.json https://raw.githubusercontent.com/Jabba-Team/index/main/index.json
+    - name: Validate Index
+      run: node src/validate.js
     - name: Push Index file
       uses: dmnemec/copy_file_to_another_repo_action@main
       env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,3 +18,18 @@ jobs:
     - run: pnpm install --frozen-lockfile
     - name: Run Tests
       run: pnpm test
+  quality:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - name: Setup Biome
+        uses: biomejs/setup-biome@v2
+        with:
+          version: latest
+      - name: Run Biome
+        run: biome ci .

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-Here's an updated README with an alternative SSH clone option:
-
----
-
 # Jabba Index Generator
 
 This repository contains a tool for automatically updating the JDK index used by [Jabba](https://github.com/shyiko/jabba), a popular Java version manager. The tool leverages the [DiscoAPI](https://api.foojay.io/disco/v2.0/) to fetch the latest JDK distributions and updates the index accordingly.

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,34 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
+	"vcs": {
+		"enabled": true,
+		"clientKind": "git",
+		"useIgnoreFile": true
+	},
+	"files": {
+		"ignoreUnknown": false
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab"
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double"
+		}
+	},
+	"assist": {
+		"enabled": true,
+		"actions": {
+			"source": {
+				"organizeImports": "on"
+			}
+		}
+	}
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,0 @@
-import globals from "globals";
-
-
-export default [
-  {languageOptions: { globals: globals.node }},
-];

--- a/package.json
+++ b/package.json
@@ -1,23 +1,23 @@
 {
-  "name": "jabba-index",
-  "version": "1.0.0",
-  "description": "a tool to update jabbas jdk index",
-  "main": "index.js",
-  "type": "module",
-  "scripts": {
-    "test": "node --test test/*.test.js"
-  },
-  "author": "Patrick McCourt",
-  "license": "ISC",
-  "devDependencies": {
-    "eslint": "9.39.1",
-    "globals": "15.9.0"
-  },
-  "dependencies": {
-    "axios": "1.13.2",
-    "semver": "7.7.3"
-  },
-  "engines": {
-    "node": ">=20.0.0"
-  }
+	"name": "jabba-index",
+	"version": "1.0.0",
+	"description": "a tool to update jabbas jdk index",
+	"main": "index.js",
+	"type": "module",
+	"scripts": {
+		"test": "node --test test/*.test.js",
+		"lint": "pnpx @biomejs/biome check --write"
+	},
+	"author": "Patrick McCourt",
+	"license": "ISC",
+	"devDependencies": {
+		"@biomejs/biome": "2.4.6"
+	},
+	"dependencies": {
+		"axios": "1.13.6",
+		"semver": "7.7.4"
+	},
+	"engines": {
+		"node": ">=20.0.0"
+	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,154 +9,88 @@ importers:
   .:
     dependencies:
       axios:
-        specifier: 1.13.2
-        version: 1.13.2
+        specifier: 1.13.6
+        version: 1.13.6
       semver:
-        specifier: 7.7.3
-        version: 7.7.3
+        specifier: 7.7.4
+        version: 7.7.4
     devDependencies:
-      eslint:
-        specifier: 9.39.1
-        version: 9.39.1
-      globals:
-        specifier: 15.9.0
-        version: 15.9.0
+      '@biomejs/biome':
+        specifier: 2.4.6
+        version: 2.4.6
 
 packages:
 
-  '@eslint-community/eslint-utils@4.9.0':
-    resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-
-  '@eslint-community/regexpp@4.12.2':
-    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
-    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
-
-  '@eslint/config-array@0.21.1':
-    resolution: {integrity: sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@eslint/config-helpers@0.4.2':
-    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@eslint/core@0.17.0':
-    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@eslint/eslintrc@3.3.3':
-    resolution: {integrity: sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@eslint/js@9.39.1':
-    resolution: {integrity: sha512-S26Stp4zCy88tH94QbBv3XCuzRQiZ9yXofEILmglYTh/Ug/a9/umqvgFtYBAo3Lp0nsI/5/qH1CCrbdK3AP1Tw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@eslint/object-schema@2.1.7':
-    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@eslint/plugin-kit@0.4.1':
-    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@humanfs/core@0.19.1':
-    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
-    engines: {node: '>=18.18.0'}
-
-  '@humanfs/node@0.16.7':
-    resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
-    engines: {node: '>=18.18.0'}
-
-  '@humanwhocodes/module-importer@1.0.1':
-    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
-    engines: {node: '>=12.22'}
-
-  '@humanwhocodes/retry@0.4.3':
-    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
-    engines: {node: '>=18.18'}
-
-  '@types/estree@1.0.8':
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
-
-  '@types/json-schema@7.0.15':
-    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
-
-  acorn-jsx@5.3.2:
-    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
-    peerDependencies:
-      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-
-  acorn@8.15.0:
-    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
-    engines: {node: '>=0.4.0'}
+  '@biomejs/biome@2.4.6':
+    resolution: {integrity: sha512-QnHe81PMslpy3mnpL8DnO2M4S4ZnYPkjlGCLWBZT/3R9M6b5daArWMMtEfP52/n174RKnwRIf3oT8+wc9ihSfQ==}
+    engines: {node: '>=14.21.3'}
     hasBin: true
 
-  ajv@6.12.6:
-    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+  '@biomejs/cli-darwin-arm64@2.4.6':
+    resolution: {integrity: sha512-NW18GSyxr+8sJIqgoGwVp5Zqm4SALH4b4gftIA0n62PTuBs6G2tHlwNAOj0Vq0KKSs7Sf88VjjmHh0O36EnzrQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
 
-  ansi-styles@4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
-    engines: {node: '>=8'}
+  '@biomejs/cli-darwin-x64@2.4.6':
+    resolution: {integrity: sha512-4uiE/9tuI7cnjtY9b07RgS7gGyYOAfIAGeVJWEfeCnAarOAS7qVmuRyX6d7JTKw28/mt+rUzMasYeZ+0R/U1Mw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
 
-  argparse@2.0.1:
-    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+  '@biomejs/cli-linux-arm64-musl@2.4.6':
+    resolution: {integrity: sha512-F/JdB7eN22txiTqHM5KhIVt0jVkzZwVYrdTR1O3Y4auBOQcXxHK4dxULf4z43QyZI5tsnQJrRBHZy7wwtL+B3A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-arm64@2.4.6':
+    resolution: {integrity: sha512-kMLaI7OF5GN1Q8Doymjro1P8rVEoy7BKQALNz6fiR8IC1WKduoNyteBtJlHT7ASIL0Cx2jR6VUOBIbcB1B8pew==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-linux-x64-musl@2.4.6':
+    resolution: {integrity: sha512-C9s98IPDu7DYarjlZNuzJKTjVHN03RUnmHV5htvqsx6vEUXCDSJ59DNwjKVD5XYoSS4N+BYhq3RTBAL8X6svEg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-x64@2.4.6':
+    resolution: {integrity: sha512-oHXmUFEoH8Lql1xfc3QkFLiC1hGR7qedv5eKNlC185or+o4/4HiaU7vYODAH3peRCfsuLr1g6v2fK9dFFOYdyw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-win32-arm64@2.4.6':
+    resolution: {integrity: sha512-xzThn87Pf3YrOGTEODFGONmqXpTwUNxovQb72iaUOdcw8sBSY3+3WD8Hm9IhMYLnPi0n32s3L3NWU6+eSjfqFg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.4.6':
+    resolution: {integrity: sha512-7++XhnsPlr1HDbor5amovPjOH6vsrFOCdp93iKXhFn6bcMUI6soodj3WWKfgEO6JosKU1W5n3uky3WW9RlRjTg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  axios@1.13.2:
-    resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
-
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+  axios@1.13.6:
+    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
-  callsites@3.1.0:
-    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
-    engines: {node: '>=6'}
-
-  chalk@4.1.2:
-    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
-    engines: {node: '>=10'}
-
-  color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
-
-  color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
-
-  cross-spawn@7.0.6:
-    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
-    engines: {node: '>= 8'}
-
-  debug@4.4.3:
-    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
-  deep-is@0.1.4:
-    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -182,76 +116,6 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
-  escape-string-regexp@4.0.0:
-    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
-    engines: {node: '>=10'}
-
-  eslint-scope@8.4.0:
-    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  eslint-visitor-keys@3.4.3:
-    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  eslint-visitor-keys@4.2.1:
-    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  eslint@9.39.1:
-    resolution: {integrity: sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    hasBin: true
-    peerDependencies:
-      jiti: '*'
-    peerDependenciesMeta:
-      jiti:
-        optional: true
-
-  espree@10.4.0:
-    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  esquery@1.6.0:
-    resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
-    engines: {node: '>=0.10'}
-
-  esrecurse@4.3.0:
-    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
-    engines: {node: '>=4.0'}
-
-  estraverse@5.3.0:
-    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
-    engines: {node: '>=4.0'}
-
-  esutils@2.0.3:
-    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
-    engines: {node: '>=0.10.0'}
-
-  fast-deep-equal@3.1.3:
-    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-
-  fast-json-stable-stringify@2.1.0:
-    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
-
-  fast-levenshtein@2.0.6:
-    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
-
-  file-entry-cache@8.0.0:
-    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
-    engines: {node: '>=16.0.0'}
-
-  find-up@5.0.0:
-    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
-    engines: {node: '>=10'}
-
-  flat-cache@4.0.1:
-    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
-    engines: {node: '>=16'}
-
-  flatted@3.3.3:
-    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
-
   follow-redirects@1.15.11:
     resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
     engines: {node: '>=4.0'}
@@ -276,25 +140,9 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
-  glob-parent@6.0.2:
-    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
-    engines: {node: '>=10.13.0'}
-
-  globals@14.0.0:
-    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
-    engines: {node: '>=18'}
-
-  globals@15.9.0:
-    resolution: {integrity: sha512-SmSKyLLKFbSr6rptvP8izbyxJL4ILwqO9Jg23UA0sDlGlu58V59D1//I3vlc0KJphVdUR7vMjHIplYnzBxorQA==}
-    engines: {node: '>=18'}
-
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
-
-  has-flag@4.0.0:
-    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
-    engines: {node: '>=8'}
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -308,56 +156,6 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  ignore@5.3.2:
-    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
-    engines: {node: '>= 4'}
-
-  import-fresh@3.3.1:
-    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
-    engines: {node: '>=6'}
-
-  imurmurhash@0.1.4:
-    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
-    engines: {node: '>=0.8.19'}
-
-  is-extglob@2.1.1:
-    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
-    engines: {node: '>=0.10.0'}
-
-  is-glob@4.0.3:
-    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
-    engines: {node: '>=0.10.0'}
-
-  isexe@2.0.0:
-    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
-    hasBin: true
-
-  json-buffer@3.0.1:
-    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
-
-  json-schema-traverse@0.4.1:
-    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
-
-  json-stable-stringify-without-jsonify@1.0.1:
-    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
-
-  keyv@4.5.4:
-    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
-
-  levn@0.4.1:
-    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
-    engines: {node: '>= 0.8.0'}
-
-  locate-path@6.0.0:
-    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
-    engines: {node: '>=10'}
-
-  lodash.merge@4.6.2:
-    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
-
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -370,180 +168,54 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
-
-  ms@2.1.3:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-
-  natural-compare@1.4.0:
-    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
-
-  optionator@0.9.4:
-    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
-    engines: {node: '>= 0.8.0'}
-
-  p-limit@3.1.0:
-    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
-    engines: {node: '>=10'}
-
-  p-locate@5.0.0:
-    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
-    engines: {node: '>=10'}
-
-  parent-module@1.0.1:
-    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
-    engines: {node: '>=6'}
-
-  path-exists@4.0.0:
-    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
-    engines: {node: '>=8'}
-
-  path-key@3.1.1:
-    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
-    engines: {node: '>=8'}
-
-  prelude-ls@1.2.1:
-    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
-    engines: {node: '>= 0.8.0'}
-
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
-  punycode@2.3.1:
-    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
-    engines: {node: '>=6'}
-
-  resolve-from@4.0.0:
-    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
-    engines: {node: '>=4'}
-
-  semver@7.7.3:
-    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
-
-  shebang-command@2.0.0:
-    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
-    engines: {node: '>=8'}
-
-  shebang-regex@3.0.0:
-    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
-    engines: {node: '>=8'}
-
-  strip-json-comments@3.1.1:
-    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
-    engines: {node: '>=8'}
-
-  supports-color@7.2.0:
-    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
-    engines: {node: '>=8'}
-
-  type-check@0.4.0:
-    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
-    engines: {node: '>= 0.8.0'}
-
-  uri-js@4.4.1:
-    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
-
-  which@2.0.2:
-    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
-    engines: {node: '>= 8'}
-    hasBin: true
-
-  word-wrap@1.2.5:
-    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
-    engines: {node: '>=0.10.0'}
-
-  yocto-queue@0.1.0:
-    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
-    engines: {node: '>=10'}
 
 snapshots:
 
-  '@eslint-community/eslint-utils@4.9.0(eslint@9.39.1)':
-    dependencies:
-      eslint: 9.39.1
-      eslint-visitor-keys: 3.4.3
+  '@biomejs/biome@2.4.6':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.4.6
+      '@biomejs/cli-darwin-x64': 2.4.6
+      '@biomejs/cli-linux-arm64': 2.4.6
+      '@biomejs/cli-linux-arm64-musl': 2.4.6
+      '@biomejs/cli-linux-x64': 2.4.6
+      '@biomejs/cli-linux-x64-musl': 2.4.6
+      '@biomejs/cli-win32-arm64': 2.4.6
+      '@biomejs/cli-win32-x64': 2.4.6
 
-  '@eslint-community/regexpp@4.12.2': {}
+  '@biomejs/cli-darwin-arm64@2.4.6':
+    optional: true
 
-  '@eslint/config-array@0.21.1':
-    dependencies:
-      '@eslint/object-schema': 2.1.7
-      debug: 4.4.3
-      minimatch: 3.1.2
-    transitivePeerDependencies:
-      - supports-color
+  '@biomejs/cli-darwin-x64@2.4.6':
+    optional: true
 
-  '@eslint/config-helpers@0.4.2':
-    dependencies:
-      '@eslint/core': 0.17.0
+  '@biomejs/cli-linux-arm64-musl@2.4.6':
+    optional: true
 
-  '@eslint/core@0.17.0':
-    dependencies:
-      '@types/json-schema': 7.0.15
+  '@biomejs/cli-linux-arm64@2.4.6':
+    optional: true
 
-  '@eslint/eslintrc@3.3.3':
-    dependencies:
-      ajv: 6.12.6
-      debug: 4.4.3
-      espree: 10.4.0
-      globals: 14.0.0
-      ignore: 5.3.2
-      import-fresh: 3.3.1
-      js-yaml: 4.1.1
-      minimatch: 3.1.2
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
+  '@biomejs/cli-linux-x64-musl@2.4.6':
+    optional: true
 
-  '@eslint/js@9.39.1': {}
+  '@biomejs/cli-linux-x64@2.4.6':
+    optional: true
 
-  '@eslint/object-schema@2.1.7': {}
+  '@biomejs/cli-win32-arm64@2.4.6':
+    optional: true
 
-  '@eslint/plugin-kit@0.4.1':
-    dependencies:
-      '@eslint/core': 0.17.0
-      levn: 0.4.1
-
-  '@humanfs/core@0.19.1': {}
-
-  '@humanfs/node@0.16.7':
-    dependencies:
-      '@humanfs/core': 0.19.1
-      '@humanwhocodes/retry': 0.4.3
-
-  '@humanwhocodes/module-importer@1.0.1': {}
-
-  '@humanwhocodes/retry@0.4.3': {}
-
-  '@types/estree@1.0.8': {}
-
-  '@types/json-schema@7.0.15': {}
-
-  acorn-jsx@5.3.2(acorn@8.15.0):
-    dependencies:
-      acorn: 8.15.0
-
-  acorn@8.15.0: {}
-
-  ajv@6.12.6:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-json-stable-stringify: 2.1.0
-      json-schema-traverse: 0.4.1
-      uri-js: 4.4.1
-
-  ansi-styles@4.3.0:
-    dependencies:
-      color-convert: 2.0.1
-
-  argparse@2.0.1: {}
+  '@biomejs/cli-win32-x64@2.4.6':
+    optional: true
 
   asynckit@0.4.0: {}
 
-  axios@1.13.2:
+  axios@1.13.6:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5
@@ -551,48 +223,14 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  balanced-match@1.0.2: {}
-
-  brace-expansion@1.1.12:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
-  callsites@3.1.0: {}
-
-  chalk@4.1.2:
-    dependencies:
-      ansi-styles: 4.3.0
-      supports-color: 7.2.0
-
-  color-convert@2.0.1:
-    dependencies:
-      color-name: 1.1.4
-
-  color-name@1.1.4: {}
-
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
-
-  concat-map@0.0.1: {}
-
-  cross-spawn@7.0.6:
-    dependencies:
-      path-key: 3.1.1
-      shebang-command: 2.0.0
-      which: 2.0.2
-
-  debug@4.4.3:
-    dependencies:
-      ms: 2.1.3
-
-  deep-is@0.1.4: {}
 
   delayed-stream@1.0.0: {}
 
@@ -616,96 +254,6 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
-
-  escape-string-regexp@4.0.0: {}
-
-  eslint-scope@8.4.0:
-    dependencies:
-      esrecurse: 4.3.0
-      estraverse: 5.3.0
-
-  eslint-visitor-keys@3.4.3: {}
-
-  eslint-visitor-keys@4.2.1: {}
-
-  eslint@9.39.1:
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1)
-      '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.1
-      '@eslint/config-helpers': 0.4.2
-      '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.3
-      '@eslint/js': 9.39.1
-      '@eslint/plugin-kit': 0.4.1
-      '@humanfs/node': 0.16.7
-      '@humanwhocodes/module-importer': 1.0.1
-      '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.8
-      ajv: 6.12.6
-      chalk: 4.1.2
-      cross-spawn: 7.0.6
-      debug: 4.4.3
-      escape-string-regexp: 4.0.0
-      eslint-scope: 8.4.0
-      eslint-visitor-keys: 4.2.1
-      espree: 10.4.0
-      esquery: 1.6.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 8.0.0
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      ignore: 5.3.2
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      json-stable-stringify-without-jsonify: 1.0.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.2
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-    transitivePeerDependencies:
-      - supports-color
-
-  espree@10.4.0:
-    dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
-      eslint-visitor-keys: 4.2.1
-
-  esquery@1.6.0:
-    dependencies:
-      estraverse: 5.3.0
-
-  esrecurse@4.3.0:
-    dependencies:
-      estraverse: 5.3.0
-
-  estraverse@5.3.0: {}
-
-  esutils@2.0.3: {}
-
-  fast-deep-equal@3.1.3: {}
-
-  fast-json-stable-stringify@2.1.0: {}
-
-  fast-levenshtein@2.0.6: {}
-
-  file-entry-cache@8.0.0:
-    dependencies:
-      flat-cache: 4.0.1
-
-  find-up@5.0.0:
-    dependencies:
-      locate-path: 6.0.0
-      path-exists: 4.0.0
-
-  flat-cache@4.0.1:
-    dependencies:
-      flatted: 3.3.3
-      keyv: 4.5.4
-
-  flatted@3.3.3: {}
 
   follow-redirects@1.15.11: {}
 
@@ -737,17 +285,7 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
-  glob-parent@6.0.2:
-    dependencies:
-      is-glob: 4.0.3
-
-  globals@14.0.0: {}
-
-  globals@15.9.0: {}
-
   gopd@1.2.0: {}
-
-  has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
 
@@ -759,48 +297,6 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  ignore@5.3.2: {}
-
-  import-fresh@3.3.1:
-    dependencies:
-      parent-module: 1.0.1
-      resolve-from: 4.0.0
-
-  imurmurhash@0.1.4: {}
-
-  is-extglob@2.1.1: {}
-
-  is-glob@4.0.3:
-    dependencies:
-      is-extglob: 2.1.1
-
-  isexe@2.0.0: {}
-
-  js-yaml@4.1.1:
-    dependencies:
-      argparse: 2.0.1
-
-  json-buffer@3.0.1: {}
-
-  json-schema-traverse@0.4.1: {}
-
-  json-stable-stringify-without-jsonify@1.0.1: {}
-
-  keyv@4.5.4:
-    dependencies:
-      json-buffer: 3.0.1
-
-  levn@0.4.1:
-    dependencies:
-      prelude-ls: 1.2.1
-      type-check: 0.4.0
-
-  locate-path@6.0.0:
-    dependencies:
-      p-locate: 5.0.0
-
-  lodash.merge@4.6.2: {}
-
   math-intrinsics@1.1.0: {}
 
   mime-db@1.52.0: {}
@@ -809,73 +305,6 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
-  minimatch@3.1.2:
-    dependencies:
-      brace-expansion: 1.1.12
-
-  ms@2.1.3: {}
-
-  natural-compare@1.4.0: {}
-
-  optionator@0.9.4:
-    dependencies:
-      deep-is: 0.1.4
-      fast-levenshtein: 2.0.6
-      levn: 0.4.1
-      prelude-ls: 1.2.1
-      type-check: 0.4.0
-      word-wrap: 1.2.5
-
-  p-limit@3.1.0:
-    dependencies:
-      yocto-queue: 0.1.0
-
-  p-locate@5.0.0:
-    dependencies:
-      p-limit: 3.1.0
-
-  parent-module@1.0.1:
-    dependencies:
-      callsites: 3.1.0
-
-  path-exists@4.0.0: {}
-
-  path-key@3.1.1: {}
-
-  prelude-ls@1.2.1: {}
-
   proxy-from-env@1.1.0: {}
 
-  punycode@2.3.1: {}
-
-  resolve-from@4.0.0: {}
-
-  semver@7.7.3: {}
-
-  shebang-command@2.0.0:
-    dependencies:
-      shebang-regex: 3.0.0
-
-  shebang-regex@3.0.0: {}
-
-  strip-json-comments@3.1.1: {}
-
-  supports-color@7.2.0:
-    dependencies:
-      has-flag: 4.0.0
-
-  type-check@0.4.0:
-    dependencies:
-      prelude-ls: 1.2.1
-
-  uri-js@4.4.1:
-    dependencies:
-      punycode: 2.3.1
-
-  which@2.0.2:
-    dependencies:
-      isexe: 2.0.0
-
-  word-wrap@1.2.5: {}
-
-  yocto-queue@0.1.0: {}
+  semver@7.7.4: {}

--- a/src/index.js
+++ b/src/index.js
@@ -1,223 +1,231 @@
 /* eslint-disable no-console */
 
-import axios from 'axios';
-import { writeFile } from 'node:fs';
-import semver from 'semver';
+import { writeFile } from "node:fs";
+import axios from "axios";
+import semver from "semver";
 
 const windowsOpts = {
-  operatingSystem: 'windows',
-  archiveTypes: ['exe', 'tar.gz', 'zip'],
-  architectures: ['amd64', 'x86'],
+	operatingSystem: "windows",
+	archiveTypes: ["exe", "tar.gz", "zip"],
+	architectures: ["amd64", "x86"],
 };
 
 const macOpts = {
-  operatingSystem: 'macos',
-  archiveTypes: ['dmg', 'zip', 'tar.gz'],
-  architectures: ['amd64', 'arm64'],
+	operatingSystem: "macos",
+	archiveTypes: ["dmg", "zip", "tar.gz"],
+	architectures: ["amd64", "arm64"],
 };
 
 const linuxOpts = {
-  operatingSystem: 'linux',
-  archiveTypes: ['zip', 'tar.gz'],
-  architectures: ['amd64', 'x86', 'arm', 'arm64'],
-  lib_c_type: 'glibc',
+	operatingSystem: "linux",
+	archiveTypes: ["zip", "tar.gz"],
+	architectures: ["amd64", "x86", "arm", "arm64"],
+	lib_c_type: "glibc",
 };
 
 const index = {
-  windows: {},
-  linux: {},
-  darwin: {},
+	windows: {},
+	linux: {},
+	darwin: {},
 };
 
 async function fetchPackages(pkgOptions) {
-  let architecture = '';
-  let extraOps = '';
-  pkgOptions.architectures.forEach((arch) => {
-    architecture += `&architecture=${arch}`;
-  });
-  let archiveType = '';
-  pkgOptions.archiveTypes.forEach((type) => {
-    archiveType += `&archive_type=${type}`;
-  });
-  if (pkgOptions.lib_c_type) {
-    extraOps = `&lib_c_type=${pkgOptions.lib_c_type}`;
-  }
-  const url = `https://api.foojay.io/disco/v3.0/packages/jdks?operating_system=${pkgOptions.operatingSystem}${architecture}&javafx_bundled=false${archiveType}${extraOps}`;
-  return axios({
-    url,
-    method: 'get',
-  }).then((response) => response.data.result);
+	let architecture = "";
+	let extraOps = "";
+	pkgOptions.architectures.forEach((arch) => {
+		architecture += `&architecture=${arch}`;
+	});
+	let archiveType = "";
+	pkgOptions.archiveTypes.forEach((type) => {
+		archiveType += `&archive_type=${type}`;
+	});
+	if (pkgOptions.lib_c_type) {
+		extraOps = `&lib_c_type=${pkgOptions.lib_c_type}`;
+	}
+	const url = `https://api.foojay.io/disco/v3.0/packages/jdks?operating_system=${pkgOptions.operatingSystem}${architecture}&javafx_bundled=false${archiveType}${extraOps}`;
+	return axios({
+		url,
+		method: "get",
+	}).then((response) => response.data.result);
 }
 
 function mapOS(os) {
-  if (os === 'macos') {
-    return 'darwin';
-  }
-  return os;
+	if (os === "macos") {
+		return "darwin";
+	}
+	return os;
 }
 
-function mapArchitecture(os, architecture) {
-  if (architecture === 'x64') {
-    return 'amd64';
-  }
-  if (architecture === 'x86') {
-    return '386';
-  }
-  if (architecture === 'aarch64') {
-    return 'arm64';
-  }
-  return architecture;
+function mapArchitecture(architecture) {
+	if (architecture === "x64") {
+		return "amd64";
+	}
+	if (architecture === "x86") {
+		return "386";
+	}
+	if (architecture === "aarch64") {
+		return "arm64";
+	}
+	return architecture;
 }
 
 function mapArchiveType(archiveType) {
-  switch (archiveType) {
-    case 'tar.gz':
-      return 'tgz+';
-    case 'zip':
-      return 'zip+';
-    case 'dmg':
-      return 'dmg+';
-    case 'exe':
-      return 'exe+';
-    default:
-      return '';
-  }
+	switch (archiveType) {
+		case "tar.gz":
+			return "tgz+";
+		case "zip":
+			return "zip+";
+		case "dmg":
+			return "dmg+";
+		case "exe":
+			return "exe+";
+		default:
+			return "";
+	}
 }
 
 function mapVersion(javaVersion) {
-  const [version] = javaVersion.split('+');
-  const semvers = version.split('.');
-  let versionOut = `${semvers[0]}`;
-  if (semvers[1]) {
-    versionOut += `.${semvers[1]}`;
-  }
-  if (semvers[2]) {
-    versionOut += `.${semvers[2]}`;
-  }
-  if (semvers[3]) {
-    versionOut += `-${semvers[3]}`;
-  }
-  return versionOut;
+	const [version] = javaVersion.split("+");
+	const semvers = version.split(".");
+	let versionOut = `${semvers[0]}`;
+	if (semvers[1]) {
+		versionOut += `.${semvers[1]}`;
+	}
+	if (semvers[2]) {
+		versionOut += `.${semvers[2]}`;
+	}
+	if (semvers[3]) {
+		versionOut += `-${semvers[3]}`;
+	}
+	return versionOut;
 }
 
 function mapLegacyVersion(jdk) {
-  const [version, plusVersion] = jdk.java_version.split('+');
-  const semvers = version.split('.');
-  if (!/^graalvm_/.test(jdk.distribution)) {
-    semvers.unshift('1');
-    while (semvers.length < 3) {
-      semvers.push('0');
-    }
-    if (version.indexOf('.') === -1 && !/^oracle/.test(jdk.distribution) &&
-      (plusVersion !== undefined || jdk.distribution !== 'zulu')) {
-      semvers.push('0');
-    }
-    if (jdk.distribution === 'corretto') {
-      const correttoRest = jdk.distribution_version.split('.').slice(3).join('.');
-      if (correttoRest.length) {
-        semvers[semvers.length - 1] += `.${correttoRest}`;
-      }
-    } else if (jdk.distribution === 'liberica' || jdk.distribution === 'zulu') {
-      if (semvers[1] === '8') {
-        semvers.splice(2, 1);
+	const [version, plusVersion] = jdk.java_version.split("+");
+	const semvers = version.split(".");
+	if (!/^graalvm_/.test(jdk.distribution)) {
+		semvers.unshift("1");
+		while (semvers.length < 3) {
+			semvers.push("0");
+		}
+		if (
+			version.indexOf(".") === -1 &&
+			!/^oracle/.test(jdk.distribution) &&
+			(plusVersion !== undefined || jdk.distribution !== "zulu")
+		) {
+			semvers.push("0");
+		}
+		if (jdk.distribution === "corretto") {
+			const correttoRest = jdk.distribution_version
+				.split(".")
+				.slice(3)
+				.join(".");
+			if (correttoRest.length) {
+				semvers[semvers.length - 1] += `.${correttoRest}`;
+			}
+		} else if (jdk.distribution === "liberica" || jdk.distribution === "zulu") {
+			if (semvers[1] === "8") {
+				semvers.splice(2, 1);
 
-        if (jdk.distribution !== 'zulu') {
-          semvers.push(plusVersion);
-        }
-      }
-    }
-  } else {
-    while (semvers.length < 3) {
-      semvers.push('0');
-    }
-  }
-  let versionOut = `${semvers[0]}`;
-  if (semvers[1]) {
-    versionOut += `.${semvers[1]}`;
-  }
-  if (semvers[2]) {
-    versionOut += `.${semvers[2]}`;
-  }
-  if (semvers[3]) {
-    versionOut += `-${semvers[3]}`;
-  }
-  return versionOut;
+				if (jdk.distribution !== "zulu") {
+					semvers.push(plusVersion);
+				}
+			}
+		}
+	} else {
+		while (semvers.length < 3) {
+			semvers.push("0");
+		}
+	}
+	let versionOut = `${semvers[0]}`;
+	if (semvers[1]) {
+		versionOut += `.${semvers[1]}`;
+	}
+	if (semvers[2]) {
+		versionOut += `.${semvers[2]}`;
+	}
+	if (semvers[3]) {
+		versionOut += `-${semvers[3]}`;
+	}
+	return versionOut;
 }
 
 function mapLegacyDistribution(distribution) {
-  switch (distribution) {
-    case 'oracle_open_jdk':
-      return 'openjdk';
-    case 'graalvm_ce8':
-      return 'graalvm-ce-java8';
-    case 'graalvm_ce19':
-      return 'graalvm-ce-java19';
-    case 'graalvm_ce17':
-      return 'graalvm-ce-java17';
-    case 'graalvm_ce16':
-      return 'graalvm-ce-java16';
-    case 'graalvm_ce11':
-      return 'graalvm-ce-java11';
-    case 'corretto':
-      return 'amazon-corretto';
-    case 'aoj_openj9':
-      return 'adopt-openj9';
-    case 'aoj':
-      return 'adopt';
-    case 'oracle':
-      return '';
-    default:
-      return null;
-  }
+	switch (distribution) {
+		case "oracle_open_jdk":
+			return "openjdk";
+		case "graalvm_ce8":
+			return "graalvm-ce-java8";
+		case "graalvm_ce19":
+			return "graalvm-ce-java19";
+		case "graalvm_ce17":
+			return "graalvm-ce-java17";
+		case "graalvm_ce16":
+			return "graalvm-ce-java16";
+		case "graalvm_ce11":
+			return "graalvm-ce-java11";
+		case "corretto":
+			return "amazon-corretto";
+		case "aoj_openj9":
+			return "adopt-openj9";
+		case "aoj":
+			return "adopt";
+		case "oracle":
+			return "";
+		default:
+			return null;
+	}
 }
 
 function parsePackages(packageList) {
-  packageList.forEach((jdkPkg) => {
-    const operatingSystem = mapOS(jdkPkg.operating_system);
-    const architecture = mapArchitecture(jdkPkg.operating_system, jdkPkg.architecture);
-    const link = jdkPkg.links.pkg_download_redirect;
-    if (!index[operatingSystem]) {
-      index[operatingSystem] = {};
-    }
+	packageList.forEach((jdkPkg) => {
+		const operatingSystem = mapOS(jdkPkg.operating_system);
+		const architecture = mapArchitecture(jdkPkg.architecture);
+		const link = jdkPkg.links.pkg_download_redirect;
+		if (!index[operatingSystem]) {
+			index[operatingSystem] = {};
+		}
 
-    const version = mapVersion(jdkPkg.java_version);
-    const type = mapArchiveType(jdkPkg.archive_type);
+		const version = mapVersion(jdkPkg.java_version);
+		const type = mapArchiveType(jdkPkg.archive_type);
 
-    if (!index[operatingSystem][architecture]) {
-      index[operatingSystem][architecture] = {};
-    }
+		if (!index[operatingSystem][architecture]) {
+			index[operatingSystem][architecture] = {};
+		}
 
-    if (!index[operatingSystem][architecture][`jdk@${jdkPkg.distribution}`]) {
-      index[operatingSystem][architecture][`jdk@${jdkPkg.distribution}`] = {};
-    }
-    const jdkDist = index[operatingSystem][architecture][`jdk@${jdkPkg.distribution}`];
-    const jdkLink = `${type}${link}`;
-    jdkDist[version] = jdkLink;
+		if (!index[operatingSystem][architecture][`jdk@${jdkPkg.distribution}`]) {
+			index[operatingSystem][architecture][`jdk@${jdkPkg.distribution}`] = {};
+		}
+		const jdkDist =
+			index[operatingSystem][architecture][`jdk@${jdkPkg.distribution}`];
+		const jdkLink = `${type}${link}`;
+		jdkDist[version] = jdkLink;
 
-    const legacyVersion = mapLegacyVersion(jdkPkg);
-    if (legacyVersion !== version) {
-      jdkDist[legacyVersion] = jdkLink;
-    }
+		const legacyVersion = mapLegacyVersion(jdkPkg);
+		if (legacyVersion !== version) {
+			jdkDist[legacyVersion] = jdkLink;
+		}
 
-    let legacyJdk = mapLegacyDistribution(jdkPkg.distribution);
-    if (legacyJdk !== null) {
-      if (legacyJdk !== '') {
-        legacyJdk = `@${legacyJdk}`;
-      }
+		let legacyJdk = mapLegacyDistribution(jdkPkg.distribution);
+		if (legacyJdk !== null) {
+			if (legacyJdk !== "") {
+				legacyJdk = `@${legacyJdk}`;
+			}
 
-      if (!index[operatingSystem][architecture][`jdk${legacyJdk}`]) {
-        index[operatingSystem][architecture][`jdk${legacyJdk}`] = jdkDist;
-      }
-    }
+			if (!index[operatingSystem][architecture][`jdk${legacyJdk}`]) {
+				index[operatingSystem][architecture][`jdk${legacyJdk}`] = jdkDist;
+			}
+		}
 
-    if (/^graalvm/.test(jdkPkg.distribution)) {
-      if (!index[operatingSystem][architecture]['jdk@graalvm']) {
-        index[operatingSystem][architecture]['jdk@graalvm'] = {};
-      }
+		if (/^graalvm/.test(jdkPkg.distribution)) {
+			if (!index[operatingSystem][architecture]["jdk@graalvm"]) {
+				index[operatingSystem][architecture]["jdk@graalvm"] = {};
+			}
 
-      index[operatingSystem][architecture]['jdk@graalvm'][legacyVersion] = jdkLink;
-    }
-  });
+			index[operatingSystem][architecture]["jdk@graalvm"][legacyVersion] =
+				jdkLink;
+		}
+	});
 }
 
 parsePackages(await fetchPackages(windowsOpts));
@@ -226,39 +234,34 @@ parsePackages(await fetchPackages(linuxOpts));
 
 // sort the index by version for each os, arch, jdk
 Object.keys(index).forEach((os) => {
-  Object.keys(index[os]).forEach((architecture) => {
-    Object.keys(index[os][architecture]).forEach((jdk) => {
-      const orderedJdk = Object.keys(index[os][architecture][jdk])
-        .sort(
-          (a, b) => {
-            let [verA, verB] = [a, b];
-            for (let i = (a.match(/\./g) || []).length; i < 2; ++i) {
-              verA += '.0';
-            }
-            for (let i = (b.match(/\./g) || []).length; i < 2; ++i) {
-              verB += '.0';
-            }
+	Object.keys(index[os]).forEach((architecture) => {
+		Object.keys(index[os][architecture]).forEach((jdk) => {
+			const orderedJdk = Object.keys(index[os][architecture][jdk])
+				.sort((a, b) => {
+					let [verA, verB] = [a, b];
+					for (let i = (a.match(/\./g) || []).length; i < 2; ++i) {
+						verA += ".0";
+					}
+					for (let i = (b.match(/\./g) || []).length; i < 2; ++i) {
+						verB += ".0";
+					}
 
-            return semver.compare(verA, verB);
-          },
-        )
-        .reverse()
-        .reduce(
-          (obj, version) => {
-            const myObj = obj;
-            myObj[version] = index[os][architecture][jdk][version];
-            return myObj;
-          },
-          {},
-        );
-      index[os][architecture][jdk] = orderedJdk;
-    });
-  });
+					return semver.compare(verA, verB);
+				})
+				.reverse()
+				.reduce((obj, version) => {
+					const myObj = obj;
+					myObj[version] = index[os][architecture][jdk][version];
+					return myObj;
+				}, {});
+			index[os][architecture][jdk] = orderedJdk;
+		});
+	});
 });
 
-writeFile('index.json', `${JSON.stringify(index, null, 4)}\n`, (err) => {
-  if (err) throw err;
-  console.log('The file has been saved!');
+writeFile("index.json", `${JSON.stringify(index, null, 4)}\n`, (err) => {
+	if (err) throw err;
+	console.log("The file has been saved!");
 });
 
 // build up an object that looks like this

--- a/src/validate.js
+++ b/src/validate.js
@@ -1,0 +1,46 @@
+import { readFile } from "node:fs/promises";
+
+const REMOVAL_THRESHOLD = 0.15; // 15% threshold
+
+function countEntries(index) {
+	let count = 0;
+	Object.values(index).forEach((os) => {
+		Object.values(os).forEach((arch) => {
+			Object.values(arch).forEach((jdk) => {
+				count += Object.keys(jdk).length;
+			});
+		});
+	});
+	return count;
+}
+
+async function validateIndex() {
+	const oldIndex = JSON.parse(await readFile("old-index.json", "utf8"));
+	const newIndex = JSON.parse(await readFile("index.json", "utf8"));
+
+	const oldCount = countEntries(oldIndex);
+	const newCount = countEntries(newIndex);
+	const diff = oldCount - newCount;
+	const percentChange = diff / oldCount;
+
+	console.log(`Old index entries: ${oldCount}`);
+	console.log(`New index entries: ${newCount}`);
+	console.log(`Difference: ${diff} (${(percentChange * 100).toFixed(2)}%)`);
+
+	if (percentChange > REMOVAL_THRESHOLD) {
+		console.error(
+			`❌ VALIDATION FAILED: ${(percentChange * 100).toFixed(2)}% of entries removed (threshold: ${REMOVAL_THRESHOLD * 100}%)`,
+		);
+		process.exit(1);
+	}
+
+	if (percentChange > 0.05) {
+		console.warn(
+			`⚠️  WARNING: ${(percentChange * 100).toFixed(2)}% of entries removed`,
+		);
+	}
+
+	console.log("✅ Validation passed");
+}
+
+validateIndex();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,46 +1,50 @@
-import { test } from 'node:test';
-import assert from 'node:assert';
-import { readFile } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
+import assert from "node:assert";
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
 
-test('index.json is generated with correct structure', async () => {
-  await import('../src/index.js');
-  await new Promise(resolve => setTimeout(resolve, 1000));
-  
-  assert(existsSync('index.json'), 'index.json should be created');
-  
-  const content = await readFile('index.json', 'utf8');
-  const index = JSON.parse(content);
-  
-  assert(typeof index === 'object', 'Index should be an object');
-  assert('windows' in index, 'Should have windows key');
-  assert('linux' in index, 'Should have linux key');
-  assert('darwin' in index, 'Should have darwin key');
-  
-  const hasData = Object.values(index).some(os => Object.keys(os).length > 0);
-  assert(hasData, 'At least one OS should have JDK data');
+test("index.json is generated with correct structure", async () => {
+	await import("../src/index.js");
+	await new Promise((resolve) => setTimeout(resolve, 1000));
+
+	assert(existsSync("index.json"), "index.json should be created");
+
+	const content = await readFile("index.json", "utf8");
+	const index = JSON.parse(content);
+
+	assert(typeof index === "object", "Index should be an object");
+	assert("windows" in index, "Should have windows key");
+	assert("linux" in index, "Should have linux key");
+	assert("darwin" in index, "Should have darwin key");
+
+	const hasData = Object.values(index).some((os) => Object.keys(os).length > 0);
+	assert(hasData, "At least one OS should have JDK data");
 });
 
-test('generated index has valid download links', async () => {
-  const content = await readFile('index.json', 'utf8');
-  const index = JSON.parse(content);
-  
-  let linkFound = false;
-  
-  Object.values(index).forEach(os => {
-    Object.values(os).forEach(arch => {
-      Object.values(arch).forEach(jdk => {
-        Object.values(jdk).forEach(link => {
-          if (typeof link === 'string' && link.includes('http')) {
-            linkFound = true;
-            assert(link.startsWith('tgz+') || link.startsWith('zip+') || 
-                   link.startsWith('dmg+') || link.startsWith('exe+'), 
-                   'Link should have proper archive type prefix');
-          }
-        });
-      });
-    });
-  });
-  
-  assert(linkFound, 'Should have at least one download link');
+test("generated index has valid download links", async () => {
+	const content = await readFile("index.json", "utf8");
+	const index = JSON.parse(content);
+
+	let linkFound = false;
+
+	Object.values(index).forEach((os) => {
+		Object.values(os).forEach((arch) => {
+			Object.values(arch).forEach((jdk) => {
+				Object.values(jdk).forEach((link) => {
+					if (typeof link === "string" && link.includes("http")) {
+						linkFound = true;
+						assert(
+							link.startsWith("tgz+") ||
+								link.startsWith("zip+") ||
+								link.startsWith("dmg+") ||
+								link.startsWith("exe+"),
+							"Link should have proper archive type prefix",
+						);
+					}
+				});
+			});
+		});
+	});
+
+	assert(linkFound, "Should have at least one download link");
 });


### PR DESCRIPTION
As reported [here](https://github.com/Jabba-Team/jabba/issues/64) an index job removed thousands of jdks.

The generators has insufficient logging to tell what actually happened but potentially the API calls failed, this PR adds a job that will validate that not too much has been removed and if it has, then don't publish the new index. 

It also adds biomejs as a linter and formatter